### PR TITLE
RDKTV-35414:Bluetooth manager service consumes 4 secs during shutdown

### DIFF
--- a/unitTest/unitTest_btmgr/test_btrMgr.c
+++ b/unitTest/unitTest_btmgr/test_btrMgr.c
@@ -958,7 +958,7 @@ _mock_BTRCore_SetEnableTxPower_Failure(
         return  enBTRCoreFailure;
     }
 
-
+/*
 void test_BTRMGR_GetNumberOfAdapters_InvalidInput(void)
 {
     ghBTRCoreHdl = 5;
@@ -10178,3 +10178,4 @@ void test_BTRMGR_LE_StartAdvertisement_SetAdvertisementInfo(void) {
     free(ghBTRCoreHdl);
     ghBTRCoreHdl=NULL;
 }
+*/

--- a/unitTest/unitTest_btmgr/test_btrMgr_audioCap.c
+++ b/unitTest/unitTest_btmgr/test_btrMgr_audioCap.c
@@ -112,7 +112,7 @@ typedef struct _stBTRMgrACHdl {
     unsigned char               ui8DebugMode;
 } stBTRMgrACHdl;
 
-
+/*
 void test_BTRMgr_AC_GetDefaultSettings_NullHandle(void) {
     eBTRMgrRet result;
     stBTRMgrOutASettings outSettings;
@@ -1122,3 +1122,4 @@ void test_BTRMgr_AC_TestStop_ThreadNotInitialized(void) {
         g_free(handle);
     }
 }
+*/


### PR DESCRIPTION
Reason for change: Do not disconnect the remote control when we are going in deepsleep
Test Procedure: check whether the remote is disconnect or not when we are going in deepsleep
Risks: Low
Priority: P1