### PR TITLE
 DELIA-67545 :Gamepad is disconnected and autoconnect is off

### DIFF
--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -9164,7 +9164,12 @@ btrMgr_DeviceStatusCb (
                     else if ((lstEventMessage.m_pairedDevice.m_deviceType == BTRMGR_DEVICE_TYPE_HID) ||
                              (lstEventMessage.m_pairedDevice.m_deviceType == BTRMGR_DEVICE_TYPE_HID_GAMEPAD)) {
                         BTRMGRLOG_DEBUG("HID Device Found ui16DevAppearanceBleSpec - %d \n",p_StatusCB->ui16DevAppearanceBleSpec);
-                        if(ghBTRMgrDevHdlLastDisconnected == lstEventMessage.m_pairedDevice.m_deviceHandle)
+                        /* Skipped posting the connection completion event here if the device tries to auto-connect
+                        * post disconnection from UI, Based on the connect wrapper initiated from UI connection
+                        * completion event will be posted.
+                        */
+                        if ((ghBTRMgrDevHdlLastDisconnected == lstEventMessage.m_pairedDevice.m_deviceHandle) ||
+                            (p_StatusCB->eDevicePrevState == enBTRCoreDevStDisconnected))
                             break;
                         if ((p_StatusCB->ui16DevAppearanceBleSpec == BTRMGR_HID_GAMEPAD_LE_APPEARANCE) &&
                             (enBTRCoreDevStLost == p_StatusCB->eDevicePrevState) &&


### PR DESCRIPTION
Reason for change: skipped posting the connection completion event after disconnection until UI initiates the connect wrapper
Test Procedure: Follow the steps in the ticket description Risks: Low
Priority: P1