### PR TITLE
DELIA-67586 : Elite controller not disconnecting on deepsleep.

### DIFF
--- a/.github/workflows/L2_test.yml
+++ b/.github/workflows/L2_test.yml
@@ -20,9 +20,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install libbluetooth-dev libtool m4 automake autoconf libdbus-1-dev libudev-dev libcjson-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-tools libcurl4-openssl-dev libglib2.0-dev gobject-introspection libgirepository-1.0-dev bluez libcairo2-dev pkg-config
-        export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
-        export GI_TYPELIB_PATH=/usr/lib/x86_64-linux-gnu/girepository-1.0
+        sudo apt-get install libbluetooth-dev libtool m4 automake autoconf libdbus-1-dev libudev-dev libcjson-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-tools libcurl4-openssl-dev libglib2.0-dev gobject-introspection libgirepository1.0-dev bluez libcairo2-dev pkg-config
 
     - name: download bluez 
       run: |
@@ -85,16 +83,11 @@ jobs:
         ls /etc/dbus-1/system.d
 
     - name: Install Python dependencies
-      run: |
-              export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
-              export GI_TYPELIB_PATH=/usr/lib/x86_64-linux-gnu/girepository-1.0
-              pip3 install dbus-python PyGObject
+      run: pip3 install dbus-python PyGObject
 
     - name: run python in background
       run: |
         sudo python3 tests/bluezMockV2.py > ./bluezMockLogs.txt &
-        sleep 5
-        ls -l ./bluezMockLogs.txt
 
     - name: run dbus monitor
       run: |

--- a/.github/workflows/L2_test.yml
+++ b/.github/workflows/L2_test.yml
@@ -20,7 +20,9 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install libbluetooth-dev libtool m4 automake autoconf libdbus-1-dev libudev-dev libcjson-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-tools libcurl4-openssl-dev libglib2.0-dev gobject-introspection libgirepository1.0-dev bluez libcairo2-dev pkg-config
+        sudo apt-get install libbluetooth-dev libtool m4 automake autoconf libdbus-1-dev libudev-dev libcjson-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-tools libcurl4-openssl-dev libglib2.0-dev gobject-introspection libgirepository-1.0-dev bluez libcairo2-dev pkg-config
+        export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
+        export GI_TYPELIB_PATH=/usr/lib/x86_64-linux-gnu/girepository-1.0
 
     - name: download bluez 
       run: |
@@ -83,11 +85,16 @@ jobs:
         ls /etc/dbus-1/system.d
 
     - name: Install Python dependencies
-      run: pip3 install dbus-python PyGObject
+      run: |
+              export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
+              export GI_TYPELIB_PATH=/usr/lib/x86_64-linux-gnu/girepository-1.0
+              pip3 install dbus-python PyGObject
 
     - name: run python in background
       run: |
         sudo python3 tests/bluezMockV2.py > ./bluezMockLogs.txt &
+        sleep 5
+        ls -l ./bluezMockLogs.txt
 
     - name: run dbus monitor
       run: |

--- a/.github/workflows/L2_test.yml
+++ b/.github/workflows/L2_test.yml
@@ -83,7 +83,7 @@ jobs:
         ls /etc/dbus-1/system.d
 
     - name: Install Python dependencies
-      run: pip3 install dbus-python PyGObject
+      run: pip3 install dbus-python PyGObject==3.50.0
 
     - name: run python in background
       run: |

--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -178,6 +178,7 @@ STATIC BTRMgrDeviceHandle               ghBTRMgrDevHdlConnInProgress = 0;
 #ifdef RDKTV_PERSIST_VOLUME
 STATIC BTRMgrDeviceHandle               ghBTRMgrDevHdlVolSetupInProgress = 0;
 #endif
+static gboolean                         isDeinitInProgress = FALSE;
 
 STATIC BTRMGR_DiscoveryHandle_t         ghBTRMgrDiscoveryHdl;
 STATIC BTRMGR_DiscoveryHandle_t         ghBTRMgrBgDiscoveryHdl;
@@ -3750,6 +3751,7 @@ BTRMGR_Init (
     GThread*        pMainLoopThread= NULL;
 
     char            lpcBtVersion[BTRCORE_STR_LEN] = {'\0'};
+    isDeinitInProgress = FALSE;
 
     if (ghBTRCoreHdl) {
         BTRMGRLOG_WARN("Already Inited; Return Success\n");
@@ -3925,7 +3927,7 @@ BTRMGR_DeInit (
     unsigned short                  ui16LoopIdx       = 0;
     BTRMGR_ConnectedDevicesList_t   lstConnectedDevices;
     unsigned int                    ui32sleepTimeOut = 1;
-
+    isDeinitInProgress = TRUE;
 
     if (btrMgr_isTimeOutSet()) {
         btrMgr_ClearDiscoveryHoldOffTimer();
@@ -10034,7 +10036,8 @@ btrMgr_ConnectionInAuthenticationCb (
             ((BTRMGR_XBOX_ELITE_VENDOR_ID == MVendorId && BTRMGR_XBOX_ELITE_PRODUCT_ID == ui32MProductId) ||
             (BTRMGR_XBOX_GAMESIR_VENDOR_ID == MVendorId && BTRMGR_XBOX_GAMESIR_PRODUCT_ID == ui32MProductId) ||
             (BTRMGR_NINTENDO_GAMESIR_VENDOR_ID == MVendorId && BTRMGR_NINTENDO_GAMESIR_PRODUCT_ID == ui32MProductId) ||
-            (BTRMGR_XBOX_ADAPTIVE_VENDOR_ID == MVendorId && BTRMGR_XBOX_ADAPTIVE_PRODUCT_ID == ui32MProductId)))) {
+            (BTRMGR_XBOX_ADAPTIVE_VENDOR_ID == MVendorId && BTRMGR_XBOX_ADAPTIVE_PRODUCT_ID == ui32MProductId))) &&
+            isDeinitInProgress != TRUE) {
 
             if (apstConnCbInfo->stKnownDevice.tDeviceId != ghBTRMgrDevHdlPairingInProgress &&
                 apstConnCbInfo->stKnownDevice.tDeviceId != ghBTRMgrDevHdlConnInProgress) {

--- a/unitTest/unitTest_btmgr/test_btrMgr_audioCap.c
+++ b/unitTest/unitTest_btmgr/test_btrMgr_audioCap.c
@@ -1093,7 +1093,7 @@ void test_BTRMgr_AC_TestStop_ThreadNotInitialized(void) {
         g_free(handle);
     }
 }
-
+/*
 void test_BTRMgr_AC_TestStart_Success(void) {
     tBTRMgrAcHdl handle = NULL;
     stBTRMgrOutASettings settings = { .i32BtrMgrOutBufMaxSize = 1024 };
@@ -1120,3 +1120,4 @@ void test_BTRMgr_AC_TestStart_Success(void) {
         }
     }
 }
+*/

--- a/unitTest/unitTest_btmgr/test_btrMgr_audioCap.c
+++ b/unitTest/unitTest_btmgr/test_btrMgr_audioCap.c
@@ -1093,7 +1093,7 @@ void test_BTRMgr_AC_TestStop_ThreadNotInitialized(void) {
         g_free(handle);
     }
 }
-/*
+
 void test_BTRMgr_AC_TestStart_Success(void) {
     tBTRMgrAcHdl handle = NULL;
     stBTRMgrOutASettings settings = { .i32BtrMgrOutBufMaxSize = 1024 };
@@ -1120,4 +1120,3 @@ void test_BTRMgr_AC_TestStart_Success(void) {
         }
     }
 }
-*/


### PR DESCRIPTION
Reason for change:
If process shutdown was in progress, reject the incoming connection from devices.

Priority: P1
Test Procedure: Put the device in DEEPSLEEP and check for connection status.

Risks: High
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>