### PR TITLE
DELIA-68052 : Elite controller status not updated properly.

### DIFF
--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -8919,7 +8919,7 @@ static gboolean btrMgr_PostOutOfRangeHoldOffTimerCb(gpointer user_data)
     BTRMGR_EventMessage_t   lstEventMessage;
     stBTRCoreDevStatusCBInfo *cb_data = (stBTRCoreDevStatusCBInfo*)user_data;
     btrMgr_MapDevstatusInfoToEventInfo ((void *)cb_data, &lstEventMessage, BTRMGR_EVENT_DEVICE_OUT_OF_RANGE);
-    if (gEliteIncomCon != 1) {
+    if (gEliteIncomCon != 1 && (btrMgr_IsDevConnected(lstEventMessage.m_pairedDevice.m_deviceHandle) != 1)) {
         BTRMGRLOG_INFO("Generated out of range event for elite\n");
         if (gfpcBBTRMgrEventOut) {
             gfpcBBTRMgrEventOut(lstEventMessage);


### PR DESCRIPTION
Reason for change:
On Posting the out of range event to UI ,Verfied whether the device is connected.

Priority: P1
Test Procedure: Follow the steps provided in description.

Risks: Low
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>