### PR TITLE
DELIA-68243 : Luna controller getting auto connected though auto connect is off

### DIFF
--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -9408,7 +9408,8 @@ btrMgr_DeviceStatusCb (
 #ifdef AUTO_CONNECT_ENABLED
                         BTRMGRLOG_DEBUG("HID Device Found ui16DevAppearanceBleSpec - %d \n",p_StatusCB->ui16DevAppearanceBleSpec);
                         if ((p_StatusCB->ui16DevAppearanceBleSpec == BTRMGR_HID_GAMEPAD_LE_APPEARANCE) &&
-                            (enBTRCoreDevStLost == p_StatusCB->eDevicePrevState) &&
+                            (enBTRCoreDevStLost == p_StatusCB->eDevicePrevState ||
+                             enBTRCoreDevStPaired == p_StatusCB->eDevicePrevState) &&
                             (lstEventMessage.m_pairedDevice.m_deviceHandle != ghBTRMgrDevHdlConnInProgress)) {
                             int auth = 0;
                             btrMgr_IncomingConnectionAuthentication(p_StatusCB,&auth);


### PR DESCRIPTION
Reason for change:
Sent external connection request to UI for acceptance after the device waked up from deepsleep.

Priority: P1
Test Procedure: Follow the steps provided in description.

Risks: Low
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>