### PR TITLE
DELIA-68059 : After manual disconnect elite controller connected.

### DIFF
--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -9416,6 +9416,10 @@ btrMgr_DeviceStatusCb (
                                 break;
                         }
 #endif //AUTO_CONNECT_ENABLED
+                        if (ghBTRMgrDevHdlLastDisconnected == lstEventMessage.m_pairedDevice.m_deviceHandle) {
+                            BTRMGRLOG_INFO("Auto connection rejection in progress after disconnection, skipped posting the device found\n");
+                            break;
+                        }
                         lstEventMessage.m_pairedDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
                         btrMgr_SetDevConnected(lstEventMessage.m_pairedDevice.m_deviceHandle, 1);
                         BTRCore_newBatteryLevelDevice(ghBTRCoreHdl);


### PR DESCRIPTION
Reason for change:
Skipped posting the device found event if auto connect reection is in progress for xbox elite.

Priority: P1
Test Procedure: Follow the steps provided in description.

Risks: Low
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>