### PR TITLE
DELIA-68318 : Unable to connect the Xbox Gen 4 Intermittently.

### DIFF
--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -9409,7 +9409,8 @@ btrMgr_DeviceStatusCb (
                         BTRMGRLOG_DEBUG("HID Device Found ui16DevAppearanceBleSpec - %d \n",p_StatusCB->ui16DevAppearanceBleSpec);
                         if ((p_StatusCB->ui16DevAppearanceBleSpec == BTRMGR_HID_GAMEPAD_LE_APPEARANCE) &&
                             (enBTRCoreDevStLost == p_StatusCB->eDevicePrevState) &&
-                            (lstEventMessage.m_pairedDevice.m_deviceHandle != ghBTRMgrDevHdlConnInProgress)) {
+                            (lstEventMessage.m_pairedDevice.m_deviceHandle != ghBTRMgrDevHdlConnInProgress) &&
+                            (lstEventMessage.m_pairedDevice.m_deviceHandle != ghBTRMgrDevHdlPairingInProgress)) {
                             int auth = 0;
                             btrMgr_IncomingConnectionAuthentication(p_StatusCB,&auth);
                             if (!auth)


### PR DESCRIPTION
Reason for change:
Skipped requesting the connection confirmation from UI if the pairing is in progress.

Priority: P1
Test Procedure: Follow the steps provided in description.

Change-Id: Ie7773a11ac924b2b10520f159439709c66a45610 Risks: Medium
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>