### PR TITLE
RDKTV-33661 : bad use of sched_yield in RDK bluetooth code affecting performance

### DIFF
--- a/src/audioCap/btrMgr_audioCap.c
+++ b/src/audioCap/btrMgr_audioCap.c
@@ -365,7 +365,6 @@ btrMgr_AC_acmDataCapture_InTask (
             }
             /* eBTRMgrACAcmDCUnknown - UNKNOWN */
             else if (leBtrMgrAcmDCCurOp == eBTRMgrACAcmDCUnknown) {
-                g_thread_yield();
             }
         }
 
@@ -400,7 +399,6 @@ btrMgr_AC_acmDataCapture_InTask (
             }
             /* eBTRMgrACAcmDCStop - STOP */
             else if (leBtrMgrAcmDCCurOp == eBTRMgrACAcmDCStop) {
-                g_thread_yield();
             }
             /* eBTRMgrACAcmDCPause - PAUSE */
             else if (leBtrMgrAcmDCCurOp == eBTRMgrACAcmDCPause) {
@@ -410,11 +408,9 @@ btrMgr_AC_acmDataCapture_InTask (
             }
             /* eBTRMgrACAcmDCExit - EXIT */
             else if (leBtrMgrAcmDCCurOp == eBTRMgrACAcmDCExit) {
-                g_thread_yield();
             }
             /* eBTRMgrACAcmDCUnknown - UNKNOWN */
             else if (leBtrMgrAcmDCCurOp == eBTRMgrACAcmDCUnknown) {
-                g_thread_yield();
             }
         }
 
@@ -1745,7 +1741,6 @@ gpointer btrMgr_AC_testDataCapture_InTask(gpointer user_data)
             }
             /* eBTRMgrACTestDCUnknown - UNKNOWN */
             else if (leBtrMgrTestDCCurOp == eBTRMgrACTestDCUnknown) {
-                g_thread_yield();
             }
         }
 
@@ -1779,7 +1774,6 @@ gpointer btrMgr_AC_testDataCapture_InTask(gpointer user_data)
             }
             /* eBTRMgrACTestDCStop - STOP */
             else if (leBtrMgrTestDCCurOp == eBTRMgrACTestDCStop) {
-                g_thread_yield();
             }
             /* eBTRMgrACTestDCPause - PAUSE */
             else if (leBtrMgrTestDCCurOp == eBTRMgrACTestDCPause) {
@@ -1789,11 +1783,9 @@ gpointer btrMgr_AC_testDataCapture_InTask(gpointer user_data)
             }
             /* eBTRMgrACTestDCExit - EXIT */
             else if (leBtrMgrTestDCCurOp == eBTRMgrACTestDCExit) {
-                g_thread_yield();
             }
             /* eBTRMgrACTestDCUnknown - UNKNOWN */
             else if (leBtrMgrTestDCCurOp == eBTRMgrACTestDCUnknown) {
-                g_thread_yield();
             }
         }
 


### PR DESCRIPTION
Reason for change: To improve performance all calls to sched_yield and g_thread_yield should be removed, as they are not required.
Priority: P1
Test Procedure: Not required
Risks: High

Signed-off-by: ddesal230 <Darshan_Desale@comcast.com>