### PR TITLE
RDKTV-36729 : btmgr take more time to shutdown.

### DIFF
--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -4029,11 +4029,12 @@ BTRMGR_DeInit (
 
             BTRCore_GetDeviceTypeClass(ghBTRCoreHdl, lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle, &lenBtrCoreDevTy, &lenBtrCoreDevCl);
             isRemoteDev = btrMgr_IsDeviceRdkRcu(&lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_serviceInfo,lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_ui16DevAppearanceBleSpec);
-            if (!isRemoteDev) {
-                if (BTRCore_DisconnectDevice(ghBTRCoreHdl, lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle, lenBtrCoreDevTy) != enBTRCoreSuccess) {
-                    BTRMGRLOG_ERROR ("Failed to Disconnect - %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
-                }
+            if (BTRCore_DisconnectDevice(ghBTRCoreHdl, lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle, lenBtrCoreDevTy) != enBTRCoreSuccess) {
+                BTRMGRLOG_ERROR ("Failed to Disconnect - %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
+            }
 
+            /* Removed the wait time for disconnection confirmation from BlueZ for remote devices. */
+            if (!isRemoteDev) {
                 do {
                     unsigned int ui32sleepIdx = 2;
 


### PR DESCRIPTION
Reason for change:
Removed the wait time for the disconnection confirmation from remotes.

Priority: P0
Test Procedure: Follow the steps provided in description.

Change-Id: I74d7590a5bef870784ae0abf7e0fd53f9e8dcb00 Risks: High
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>