### PR TITLE
DELIA-68249: Post Reboot UI is not showing gamepad as connected

### DIFF
--- a/include/btmgr.h
+++ b/include/btmgr.h
@@ -1023,6 +1023,17 @@ BTRMGR_Result_t BTRMGR_GetDeviceProperties(unsigned char aui8AdapterIdx, BTRMgrD
 BTRMGR_Result_t BTRMGR_GetDeviceBatteryLevel (unsigned char aui8AdapterIdx, BTRMgrDeviceHandle ahBTRMgrDevHdl,unsigned char * pDeviceBatteryLevel);
 
 /**
+ * @brief  This API initates or reports the gamepad connections from the device with operation type.
+ *
+ * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.
+ * @param[in]  aenBTRMgrDevConT     Device opeartion type.
+ *
+ * @return Returns the status of the operation.
+ * @retval eBTRMgrSuccess on success, appropriate error code otherwise.
+ */
+BTRMGR_Result_t BTRMGR_ConnectGamepads_StartUp(unsigned char aui8AdapterIdx, BTRMGR_DeviceOperationType_t aenBTRMgrDevConT);
+
+/**
  * @brief  This API initates the streaming from the device with default operation type.
  *
  * @param[in]  aui8AdapterIdx       Index of bluetooth adapter.

--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -5947,6 +5947,87 @@ BTRMGR_GetDeviceBatteryLevel (
 }
 #ifndef LE_MODE
 BTRMGR_Result_t
+BTRMGR_ConnectGamepads_StartUp (
+    unsigned char                   aui8AdapterIdx,
+    BTRMGR_DeviceOperationType_t    aenBTRMgrDevConT
+) {
+    BTRMGR_Result_t           lenBtrMgrResult = BTRMGR_RESULT_SUCCESS;
+    int                       auth;
+    stBTRCoreDevStatusCBInfo  stRecreatedEvent = { 0 };
+    BTRMGR_EventMessage_t     lstEventMessage;
+
+    char lcPowerState[BTRMGR_LE_STR_LEN_MAX] = {'\0'};
+    BTRMGR_SysDiagChar_t lpcPowerString = BTRMGR_SYS_DIAG_POWERSTATE;
+
+    if (eBTRMgrSuccess == BTRMGR_SD_GetData(ghBTRMgrSdHdl, lpcPowerString, lcPowerState)) {
+        if(strncmp(lcPowerState, BTRMGR_SYS_DIAG_PWRST_ON, strlen(BTRMGR_SYS_DIAG_PWRST_ON) != 0))
+        {
+            BTRMGRLOG_ERROR("Power state is %s no need to try connecting device as it will connect once ON\n", lcPowerState);
+            return BTRMGR_RESULT_GENERIC_FAILURE;
+        }
+        else
+        {
+            BTRMGRLOG_INFO("Power state is ON\n");
+        }
+    }
+    else
+    {
+        BTRMGRLOG_ERROR("Could not get power state\n");
+    }
+
+    BTRMGR_GetPairedDevices (aui8AdapterIdx, &gListOfPairedDevices);
+    for (unsigned char i = 0; i < gListOfPairedDevices.m_numOfDevices; i++)
+    {
+        stBTRCoreBTDevice stDeviceInfo = { 0 };
+        btrMgr_GetDeviceDetails(gListOfPairedDevices.m_deviceProperty[i].m_deviceHandle, &stDeviceInfo);
+        if (stDeviceInfo.bDeviceConnected
+        && (gListOfPairedDevices.m_deviceProperty[i].m_deviceType == BTRMGR_DEVICE_TYPE_HID
+        || gListOfPairedDevices.m_deviceProperty[i].m_deviceType ==BTRMGR_DEVICE_TYPE_HID_GAMEPAD)
+        && (!btrMgr_IsDeviceRdkRcu(&gListOfPairedDevices.m_deviceProperty[i].m_serviceInfo, stDeviceInfo.ui16DevAppearanceBleSpec)))
+        {
+            strncpy(stRecreatedEvent.deviceName, stDeviceInfo.pcDeviceName, BTRMGR_NAME_LEN_MAX - 1);
+            strncpy(stRecreatedEvent.deviceAddress, stDeviceInfo.pcDeviceAddress, BTRMGR_NAME_LEN_MAX - 1);
+            stRecreatedEvent.deviceId = stDeviceInfo.tDeviceId;
+            stRecreatedEvent.eDeviceClass = stDeviceInfo.enDeviceType;
+            stRecreatedEvent.eDeviceType = stDeviceInfo.enDeviceType;
+            stRecreatedEvent.isPaired = 1;
+            stRecreatedEvent.ui32VendorId = stDeviceInfo.ui32ModaliasVendorId;
+            stRecreatedEvent.ui32ProductId = stDeviceInfo.ui32ModaliasProductId;
+            stRecreatedEvent.ui32DeviceId = stDeviceInfo.ui32ModaliasDeviceId;
+            stRecreatedEvent.ui16DevAppearanceBleSpec = stDeviceInfo.ui16DevAppearanceBleSpec;
+            stRecreatedEvent.eDevicePrevState = enBTRCoreDevStPaired;
+            stRecreatedEvent.eDeviceCurrState = enBTRCoreDevStConnected;
+
+
+            //recreate event that would have been received from the connectCb
+            btrMgr_IncomingConnectionAuthentication(&stRecreatedEvent, &auth);
+
+            if (!auth)
+                continue;
+
+            btrMgr_MapDevstatusInfoToEventInfo ((void *)&stRecreatedEvent, &lstEventMessage, BTRMGR_EVENT_DEVICE_FOUND);
+            lstEventMessage.m_pairedDevice.m_deviceType = BTRMGR_DEVICE_TYPE_HID;
+            btrMgr_SetDevConnected(lstEventMessage.m_pairedDevice.m_deviceHandle, 1);
+            BTRCore_newBatteryLevelDevice(ghBTRCoreHdl);
+
+            BTRMGRLOG_DEBUG("Posting Device Found Event ..\n");
+
+            if (gbGamepadStandbyMode && ((lstEventMessage.m_pairedDevice.m_deviceType == BTRMGR_DEVICE_TYPE_HID) ||
+                (lstEventMessage.m_pairedDevice.m_deviceType == BTRMGR_DEVICE_TYPE_HID_GAMEPAD)))
+            {
+                BTRMGRLOG_WARN("Device is in standby mode, we won't post to the upper layers if a device is found\n");
+                continue;
+            }
+            if (gfpcBBTRMgrEventOut) {
+                gfpcBBTRMgrEventOut(lstEventMessage);
+            }
+        }
+    }
+
+    return lenBtrMgrResult;
+}
+
+BTRMGR_Result_t
 BTRMGR_StartAudioStreamingOut_StartUp (
     unsigned char                   aui8AdapterIdx,
     BTRMGR_DeviceOperationType_t    aenBTRMgrDevConT
@@ -9008,6 +9089,9 @@ btrMgr_ConnPwrStChangeTimerCb (
     if ( ghBTRMgrDevHdlCurStreaming == 0 ) {
             if( BTRMGR_StartAudioStreamingOut_StartUp(lui8AdapterIdx, BTRMGR_DEVICE_OP_TYPE_AUDIO_OUTPUT) != BTRMGR_RESULT_SUCCESS) {
                      BTRMGRLOG_ERROR ("ConnPwrStChange - BTRMGR_StartAudioStreamingOut_StartUp Failed!\n");
+            }
+            if( BTRMGR_ConnectGamepads_StartUp(lui8AdapterIdx, BTRMGR_DEVICE_OP_TYPE_HID) != BTRMGR_RESULT_SUCCESS) {
+                     BTRMGRLOG_ERROR ("ConnPwrStChange - BTRMGR_ConnectGamepads_StartUp Failed!\n");
             }
     }
 

--- a/src/main/btrMgr_main.c
+++ b/src/main/btrMgr_main.c
@@ -108,6 +108,11 @@ main (
         lenBtrMgrSoResult = BTRMGR_StartAudioStreamingOut_StartUp(0, BTRMGR_DEVICE_OP_TYPE_AUDIO_OUTPUT);
         printf ("BTRMGR_StartAudioStreamingOut_StartUp - %d\n", lenBtrMgrSoResult);
         fflush(stdout);
+        
+        lenBtrMgrSoResult = BTRMGR_ConnectGamepads_StartUp(0, BTRMGR_DEVICE_OP_TYPE_HID);
+        printf ("BTRMGR_StartAudioStreamingOut_StartUp - %d\n", lenBtrMgrSoResult);
+        fflush(stdout);
+
 #endif
 
 #if defined(ENABLE_SD_NOTIFY)


### PR DESCRIPTION
Reason for change: if a connection occurs before btmgr comes up, btmgr will not send an event for the connection
Test Procedure: reboot a gamepad and make sure the gamepad is on for when the device starts coming up - when you go to the gaming UI you should see the gamepad
Risks: Low
Priority: P1