### PR TITLE
RDKEVD-2986 : Bluetooth device not connected automatically to TV ,

### DIFF
--- a/src/main/btrMgr_main.c
+++ b/src/main/btrMgr_main.c
@@ -49,7 +49,8 @@
 
 static bool gbExitBTRMgr = false;
 
-
+#define BT_MAX_HCICONFIG_OUTPUT_SIZE    1024
+#define BT_HCI0_TIMEOUT 30
 static void
 btrMgr_SignalHandler (
     int i32SignalNumber
@@ -64,6 +65,35 @@ btrMgr_SignalHandler (
         gbExitBTRMgr = true;
 }
 
+static unsigned char btrMgr_systemReady() {
+
+    char output[BT_MAX_HCICONFIG_OUTPUT_SIZE] = {0};
+    FILE* fp;
+    int output_length = 0;
+
+    // Execute hciconfig -a command and capture its output
+    fp = popen("hciconfig hci0", "r");
+    if (fp == NULL) {
+            printf("Failed to execute hciconfig\n");
+            return -1;
+    }
+
+    output_length = fread(output, sizeof(char), BT_MAX_HCICONFIG_OUTPUT_SIZE - 1, fp);
+    output[output_length] = '\0';
+    pclose(fp);
+
+    if (strstr(output, "UP RUNNING"))
+    {
+        printf("Hci0 is up\n");
+        return 1;
+    }
+    else 
+    {
+        printf("Hci0 is not yet up\n");
+        return 0;
+    }
+    return 0;
+}
 
 int
 main (
@@ -77,6 +107,18 @@ main (
     BTRMGR_Result_t lenBtrMgrSoResult   = BTRMGR_RESULT_SUCCESS;
 #endif
 
+    //verify that the hci interface is up or fail after 30 seconds
+    unsigned char timeout = 0;
+    while (!btrMgr_systemReady() && timeout < BT_HCI0_TIMEOUT)
+    {
+        timeout++;
+        sleep(1);
+    }
+    if (timeout == BT_HCI0_TIMEOUT)
+    {
+        printf("HCI is not up, btmgr will most likely fail to start\n");
+    }
+    
     if ((lenBtrMgrResult = BTRMGR_Init()) == BTRMGR_RESULT_SUCCESS) {
 
         signal(SIGTERM, btrMgr_SignalHandler);
@@ -110,7 +152,7 @@ main (
         fflush(stdout);
 
         lenBtrMgrSoResult = BTRMGR_ConnectGamepads_StartUp(0, BTRMGR_DEVICE_OP_TYPE_HID);
-        printf ("BTRMGR_StartAudioStreamingOut_StartUp - %d\n", lenBtrMgrSoResult);
+        printf ("BTRMGR_ConnectGamepads_StartUp - %d\n", lenBtrMgrSoResult);
         fflush(stdout);
 #endif
 


### PR DESCRIPTION
Reason for change: wait for hci interface to come up before starting btmgr  
Signed-off-by: Ananth Marimuthu <ananth_marimuthu2@comcast.com>