### PR TITLE
RDKEMW-8277 : The Controller is not showing disconnected in UI.

### DIFF
--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -5555,20 +5555,21 @@ BTRMGR_DisconnectFromDevice (
 
             if (lenBTRCoreDevTy == enBTRCoreLE) {
                 gIsLeDeviceConnected = 0;
-            }
-            else if ((lenBTRCoreDevTy == enBTRCoreSpeakers) || (lenBTRCoreDevTy == enBTRCoreHeadSet)) {
-                btrMgr_SetDevConnected(ahBTRMgrDevHdl, 0);
-                ghBTRMgrDevHdlLastConnected = 0;
-            }
-            else if ((lenBTRCoreDevTy == enBTRCoreMobileAudioIn) || (lenBTRCoreDevTy == enBTRCorePCAudioIn)) {
-                btrMgr_SetDevConnected(ahBTRMgrDevHdl, 0);
-                ghBTRMgrDevHdlLastConnected = 0;
-            }
-            else if (lenBTRCoreDevTy == enBTRCoreHID) {
-                btrMgr_SetDevConnected(ahBTRMgrDevHdl, 0);
-            }
-            else {
-                btrMgr_SetDevConnected(ahBTRMgrDevHdl, 0);
+            } else {
+                gIsUserInitiated = 0;
+                if ((lenBTRCoreDevTy == enBTRCoreSpeakers) ||
+                    (lenBTRCoreDevTy == enBTRCoreHeadSet) ||
+                    (lenBTRCoreDevTy == enBTRCoreMobileAudioIn) ||
+                    (lenBTRCoreDevTy == enBTRCorePCAudioIn)) {
+                    btrMgr_SetDevConnected(ahBTRMgrDevHdl, 0);
+                    ghBTRMgrDevHdlLastConnected = 0;
+                }
+                else if (lenBTRCoreDevTy == enBTRCoreHID) {
+                    btrMgr_SetDevConnected(ahBTRMgrDevHdl, 0);
+                }
+                else {
+                    btrMgr_SetDevConnected(ahBTRMgrDevHdl, 0);
+                }
             }
 
             if ((lenBTRCoreDevTy == enBTRCoreSpeakers) || (lenBTRCoreDevTy == enBTRCoreHeadSet)) {


### PR DESCRIPTION
Reason for change:
Allow the out of range event to be posted after the disconnetion process has been completed.

Priority: P1
Test Procedure: Follow the steps provided in description.

Risks: Low
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>