### PR TITLE
RDKTV-39415 : [RDKE] [CI] BT scan Stop API call doesn't stop scan

### DIFF
--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -4771,10 +4771,10 @@ BTRMGR_StopDeviceDiscovery_Internal (
         lenBtrMgrResult = BTRMGR_RESULT_GENERIC_FAILURE;
     }
     else {
-        BTRMGRLOG_INFO ("Discovery Stopped Successfully\n");
+        BTRMGRLOG_INFO ("Stop discovery requested successfully\n");
 
-        {   /* Max 3 sec timeout - Polled at 50ms second interval */
-            unsigned int ui32sleepIdx = 60;
+        {   /* Max 6 sec timeout - Polled at 50ms interval */
+            unsigned int ui32sleepIdx = 120;
 
             while ((gIsAdapterDiscovering) && (ui32sleepIdx--)) {
                 usleep(50000);


### PR DESCRIPTION
Reason for change: increased timeout to allow discovery process to complete
Test Procedure: Check Ticket description
Risks: Low
Priority: P2