### PR TITLE
RDKEMW-18086 : Factory Reset takes more than 7 seconds.

### DIFF
--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -194,6 +194,7 @@ STATIC BTRMgrDeviceHandle               ghBTRMgrDevHdlConnInProgress = 0;
 STATIC BTRMgrDeviceHandle               ghBTRMgrDevHdlVolSetupInProgress = 0;
 #endif
 gboolean                                isDeinitInProgress = FALSE;
+gboolean                                SkipDiscoveryOps   = FALSE;
 
 STATIC BTRMGR_DiscoveryHandle_t         ghBTRMgrDiscoveryHdl;
 STATIC BTRMGR_DiscoveryHandle_t         ghBTRMgrBgDiscoveryHdl;
@@ -3916,6 +3917,7 @@ BTRMGR_Init (
     char btmgr_name[] = "btmgr";
     telemetry_init(btmgr_name);
     isDeinitInProgress = FALSE;
+    SkipDiscoveryOps = FALSE;
     /* Initialze all the database */
     MEMSET_S(&gDefaultAdapterContext, sizeof(gDefaultAdapterContext), 0, sizeof(gDefaultAdapterContext));
     MEMSET_S(&gListOfAdapters, sizeof(gListOfAdapters), 0, sizeof(gListOfAdapters));
@@ -4110,6 +4112,7 @@ BTRMGR_DeInit (
         lenBtrMgrRet = btrMgr_StopDeviceDiscovery (0, ldiscoveryHdl);
         BTRMGRLOG_DEBUG ("Exit Discovery Status = %d\n", lenBtrMgrRet);
     }
+    SkipDiscoveryOps = TRUE;
 
     if ((lenBtrMgrResult = BTRMGR_GetConnectedDevices(0, &lstConnectedDevices)) == BTRMGR_RESULT_SUCCESS) {
         BTRMGRLOG_DEBUG ("Connected Devices = %d\n", lstConnectedDevices.m_numOfDevices);
@@ -4638,6 +4641,11 @@ BTRMGR_StartDeviceDiscovery_Internal (
         return BTRMGR_RESULT_INVALID_INPUT;
     }
 
+    if (SkipDiscoveryOps) {
+        BTRMGRLOG_ERROR ("Process shutdown in progress, skipping start discovery\n");
+        return BTRMGR_RESULT_GENERIC_FAILURE;
+    }
+
     if (!(pAdapterPath = btrMgr_GetAdapterPath(aui8AdapterIdx))) {
         BTRMGRLOG_ERROR ("Failed to get adapter path\n");
         return BTRMGR_RESULT_GENERIC_FAILURE;
@@ -4690,7 +4698,8 @@ BTRMGR_StartDeviceDiscovery_Internal (
         lenBtrMgrResult = BTRMGR_RESULT_GENERIC_FAILURE;
     }
     else {
-        {   /* Max 5 sec timeout - Polled at 5ms second interval */
+        /* Max 5 sec timeout - Polled at 5ms second interval */
+        if (!isDeinitInProgress) {
             unsigned int ui32sleepIdx = 1000;
 
             do {
@@ -4738,6 +4747,11 @@ BTRMGR_StopDeviceDiscovery_Internal (
         return BTRMGR_RESULT_GENERIC_FAILURE;
     }
 
+    if (SkipDiscoveryOps) {
+        BTRMGRLOG_ERROR ("Process shutdown in progress, skipping stop discovery\n");
+        return BTRMGR_RESULT_GENERIC_FAILURE;
+    }
+
     if (!(ahdiscoveryHdl = btrMgr_GetDiscoveryInProgress())) {
         BTRMGRLOG_WARN("Scanning is not running now\n");
     }
@@ -4773,7 +4787,8 @@ BTRMGR_StopDeviceDiscovery_Internal (
     else {
         BTRMGRLOG_INFO ("Stop discovery requested successfully\n");
 
-        {   /* Max 6 sec timeout - Polled at 50ms interval */
+        /* Max 6 sec timeout - Polled at 50ms interval */
+        if (!isDeinitInProgress) {
             unsigned int ui32sleepIdx = 120;
 
             while ((gIsAdapterDiscovering) && (ui32sleepIdx--)) {

--- a/unitTest/unitTest_btmgr/test_btrMgr.c
+++ b/unitTest/unitTest_btmgr/test_btrMgr.c
@@ -67,6 +67,7 @@ extern void *gpvMainLoopThread;
 extern tBTRCoreHandle ghBTRCoreHdl;
 extern tBTRMgrPIHdl ghBTRMgrPiHdl;
 extern bool isDeinitInProgress;
+extern bool SkipDiscoveryOps;
 extern stBTRCoreListAdapters gListOfAdapters;
 extern BTRMGR_PairedDevicesList_t gListOfPairedDevices;
 extern BTRMGR_DiscoveredDevicesList_t gListOfDiscoveredDevices;
@@ -5675,7 +5676,7 @@ void test_BTRMGR_DeInit_NoConnectedDevices(void)
 {
     // Mock no connected devices
     // BTRMGR_GetConnectedDevices_ExpectAndReturn(0, NULL, BTRMGR_RESULT_SUCCESS);
-
+    SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)1;
     BTRCore_GetListOfPairedDevices_StubWithCallback(_mock_BTRCore_GetListOfPairedDevices_Success);
     BTRCore_GetListOfScannedDevices_StubWithCallback(_mock_return_ScannedList);
@@ -5690,6 +5691,7 @@ void test_BTRMGR_DeInit_MainLoopAndThreadCleanup(void)
 {
     // Mock main loop and thread cleanup
 
+    SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)1;
     unsigned char aui8AdapterIdx;
     aui8AdapterIdx = 0;
@@ -5703,7 +5705,6 @@ void test_BTRMGR_DeInit_MainLoopAndThreadCleanup(void)
 
     BTRMGR_Result_t result = BTRMGR_DeInit();
     TEST_ASSERT_EQUAL(BTRMGR_RESULT_SUCCESS, result);
-
     
 }
 
@@ -5774,6 +5775,7 @@ void test_BTRMGR_DeInit_BTRCoreDeinitFailure(void)
 void test_BTRMGR_DeInit_Success(void)
 {
     // Mock successful deinitialization
+    SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)malloc(sizeof(stBTRCoreHdl)); // Allocate memory for BTRCore handle
     BTRMGR_ConnectedDevicesList_t lstConnectedDevices = {0};
     lstConnectedDevices.m_numOfDevices = 0; // No connected devices
@@ -5874,6 +5876,7 @@ void test_BTRMGR_DeInit_FailedCoreDeinit(void)
 }
 void test_BTRMGR_StopDeviceDiscovery_Success(void)
 {
+    SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)1; // Simulate initialized BTRCore handle
     BTRMGR_DeviceOperationType_t devOpType = BTRMGR_DEVICE_OP_TYPE_LE;
 
@@ -6012,6 +6015,7 @@ void test_BTRMGR_StartAudioStreamingIn_InvalidInput(void)
 }
 void test_BTRMGR_StartAudioStreamingIn_Success(void)
 {
+    SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)1; // Simulate initialized BTRCore handle
 
     BTRCore_GetListOfPairedDevices_StubWithCallback(_mock_BTRCore_GetListOfPairedDevices_Success);
@@ -6127,6 +6131,7 @@ void test_BTRMGR_StartAudioStreamingIn_StartFailed(void) {
 }
 
 void test_BTRMGR_StartAudioStreamingIn_Failure_StopPreviousStreamingIn(void) {
+    SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)1; // Simulate initialized BTRCore handle
     ghBTRMgrDevHdlCurStreaming = 12345; // Simulate a device currently streaming in
     //BTRMgrDeviceHandle ahBTRMgrDevHdl;

--- a/unitTest/unitTest_btmgr/test_btrMgr.c
+++ b/unitTest/unitTest_btmgr/test_btrMgr.c
@@ -5678,6 +5678,7 @@ void test_BTRMGR_DeInit_NoConnectedDevices(void)
     // BTRMGR_GetConnectedDevices_ExpectAndReturn(0, NULL, BTRMGR_RESULT_SUCCESS);
     SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)1;
+    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
     BTRCore_GetListOfPairedDevices_StubWithCallback(_mock_BTRCore_GetListOfPairedDevices_Success);
     BTRCore_GetListOfScannedDevices_StubWithCallback(_mock_return_ScannedList);
     BTRMgr_SD_DeInit_IgnoreAndReturn(eBTRMgrSuccess);
@@ -5693,6 +5694,7 @@ void test_BTRMGR_DeInit_MainLoopAndThreadCleanup(void)
 
     SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)1;
+    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
     unsigned char aui8AdapterIdx;
     aui8AdapterIdx = 0;
     BTRMGR_ConnectedDevicesList_t *pConnectedDevices;
@@ -5713,6 +5715,7 @@ void test_BTRMGR_DeInit_SDModuleDeinitFailure(void)
     // Mock SD module deinitialization failure
 
     ghBTRCoreHdl = (tBTRCoreHandle)1;
+    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
     unsigned char aui8AdapterIdx;
     aui8AdapterIdx = 0;
     BTRMGR_ConnectedDevicesList_t *pConnectedDevices;
@@ -5734,6 +5737,7 @@ void test_BTRMGR_DeInit_PIModuleDeinitFailure(void)
 {
     //     // Mock PI module deinitialization failure
     ghBTRCoreHdl = (tBTRCoreHandle)1;
+    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
     unsigned char aui8AdapterIdx;
     aui8AdapterIdx = 0;
     BTRMGR_ConnectedDevicesList_t *pConnectedDevices;
@@ -5756,6 +5760,7 @@ void test_BTRMGR_DeInit_BTRCoreDeinitFailure(void)
 {
     // Mock BTRCore deinitialization failure
     ghBTRCoreHdl = (tBTRCoreHandle)1;
+    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
     unsigned char aui8AdapterIdx;
     aui8AdapterIdx = 0;
     BTRMGR_ConnectedDevicesList_t *pConnectedDevices;
@@ -5777,6 +5782,7 @@ void test_BTRMGR_DeInit_Success(void)
     // Mock successful deinitialization
     SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)malloc(sizeof(stBTRCoreHdl)); // Allocate memory for BTRCore handle
+    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
     BTRMGR_ConnectedDevicesList_t lstConnectedDevices = {0};
     lstConnectedDevices.m_numOfDevices = 0; // No connected devices
 

--- a/unitTest/unitTest_btmgr/test_btrMgr.c
+++ b/unitTest/unitTest_btmgr/test_btrMgr.c
@@ -5678,7 +5678,7 @@ void test_BTRMGR_DeInit_NoConnectedDevices(void)
     // BTRMGR_GetConnectedDevices_ExpectAndReturn(0, NULL, BTRMGR_RESULT_SUCCESS);
     SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)1;
-    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
+    BTRCore_StopDiscovery_IgnoreAndReturn(enBTRCoreSuccess);
     BTRCore_GetListOfPairedDevices_StubWithCallback(_mock_BTRCore_GetListOfPairedDevices_Success);
     BTRCore_GetListOfScannedDevices_StubWithCallback(_mock_return_ScannedList);
     BTRMgr_SD_DeInit_IgnoreAndReturn(eBTRMgrSuccess);
@@ -5694,7 +5694,7 @@ void test_BTRMGR_DeInit_MainLoopAndThreadCleanup(void)
 
     SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)1;
-    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
+    BTRCore_StopDiscovery_IgnoreAndReturn(enBTRCoreSuccess);
     unsigned char aui8AdapterIdx;
     aui8AdapterIdx = 0;
     BTRMGR_ConnectedDevicesList_t *pConnectedDevices;
@@ -5715,7 +5715,7 @@ void test_BTRMGR_DeInit_SDModuleDeinitFailure(void)
     // Mock SD module deinitialization failure
 
     ghBTRCoreHdl = (tBTRCoreHandle)1;
-    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
+    BTRCore_StopDiscovery_IgnoreAndReturn(enBTRCoreSuccess);
     unsigned char aui8AdapterIdx;
     aui8AdapterIdx = 0;
     BTRMGR_ConnectedDevicesList_t *pConnectedDevices;
@@ -5737,7 +5737,7 @@ void test_BTRMGR_DeInit_PIModuleDeinitFailure(void)
 {
     //     // Mock PI module deinitialization failure
     ghBTRCoreHdl = (tBTRCoreHandle)1;
-    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
+    BTRCore_StopDiscovery_IgnoreAndReturn(enBTRCoreSuccess);
     unsigned char aui8AdapterIdx;
     aui8AdapterIdx = 0;
     BTRMGR_ConnectedDevicesList_t *pConnectedDevices;
@@ -5760,7 +5760,7 @@ void test_BTRMGR_DeInit_BTRCoreDeinitFailure(void)
 {
     // Mock BTRCore deinitialization failure
     ghBTRCoreHdl = (tBTRCoreHandle)1;
-    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
+    BTRCore_StopDiscovery_IgnoreAndReturn(enBTRCoreSuccess);
     unsigned char aui8AdapterIdx;
     aui8AdapterIdx = 0;
     BTRMGR_ConnectedDevicesList_t *pConnectedDevices;
@@ -5782,7 +5782,7 @@ void test_BTRMGR_DeInit_Success(void)
     // Mock successful deinitialization
     SkipDiscoveryOps = false;
     ghBTRCoreHdl = (tBTRCoreHandle)malloc(sizeof(stBTRCoreHdl)); // Allocate memory for BTRCore handle
-    BTRCore_StopDiscovery_ExpectAndReturn(ghBTRCoreHdl, 0, enBTRCoreSuccess);
+    BTRCore_StopDiscovery_IgnoreAndReturn(enBTRCoreSuccess);
     BTRMGR_ConnectedDevicesList_t lstConnectedDevices = {0};
     lstConnectedDevices.m_numOfDevices = 0; // No connected devices
 

--- a/unitTest/unitTest_btmgr/test_btrMgr.c
+++ b/unitTest/unitTest_btmgr/test_btrMgr.c
@@ -124,7 +124,7 @@ void setUp(void)
     gstBTRMgrStreamingInfo.channels = 0;
     gstBTRMgrStreamingInfo.bitsPerSample = 0;
     gstBTRMgrStreamingInfo.i32BytesToEncode = 0;
-
+    isDeinitInProgress = FALSE;
 }
 void tearDown(void) {
     // Clean up any necessary variables or state after each test


### PR DESCRIPTION
Reason for change: Skipped start/stop discovery when process shutdown going on.
Test Procedure: ensure no regressions with bluetooth feature Risks: High
Priority: P0