### PR TITLE
RDK-61371 : Migrating Ble pairing data to /opt/secure/lib

### DIFF
--- a/include/persistIf/btrMgr_persistIface.h
+++ b/include/persistIf/btrMgr_persistIface.h
@@ -43,7 +43,7 @@
 #ifdef UNIT_TEST
 #define BTRMGR_PERSISTENT_DATA_PATH JSON_PATH_UNIT_TEST
 #else
-#define BTRMGR_PERSISTENT_DATA_PATH "/opt/lib/bluetooth/btmgrPersist.json"
+#define BTRMGR_PERSISTENT_DATA_PATH "/opt/secure/lib/bluetooth/btmgrPersist.json"
 #endif
 #define BTRMGR_A2DP_SRC_PROFILE_ID  "0x110a"
 #define BTRMGR_A2DP_SINK_PROFILE_ID "0x110b"


### PR DESCRIPTION
Reason for change: Migrate bluetooth pairing data to /opt/secure
Test Procedure: Do bluetooth regression test

Risks: Medium
Priority: P1