### PR TITLE
RDK-61371 : Migrating Ble pairing data to /opt/secure/lib

### DIFF
--- a/include/persistIf/btrMgr_persistIface.h
+++ b/include/persistIf/btrMgr_persistIface.h
@@ -45,7 +45,6 @@
 #else
 #define BTRMGR_PERSISTENT_DATA_PATH_OPT_LIB "/opt/lib/bluetooth/btmgrPersist.json"
 #define BTRMGR_PERSISTENT_DATA_PATH_SECURE "/opt/secure/lib/bluetooth/btmgrPersist.json"
-#define BTRMGR_PERSISTENT_DATA_PATH BTRMGR_PERSISTENT_DATA_PATH_SECURE
 #endif
 #define BTRMGR_A2DP_SRC_PROFILE_ID  "0x110a"
 #define BTRMGR_A2DP_SINK_PROFILE_ID "0x110b"

--- a/include/persistIf/btrMgr_persistIface.h
+++ b/include/persistIf/btrMgr_persistIface.h
@@ -43,7 +43,9 @@
 #ifdef UNIT_TEST
 #define BTRMGR_PERSISTENT_DATA_PATH JSON_PATH_UNIT_TEST
 #else
-#define BTRMGR_PERSISTENT_DATA_PATH "/opt/lib/bluetooth/btmgrPersist.json"
+#define BTRMGR_PERSISTENT_DATA_PATH_OPT_LIB "/opt/lib/bluetooth/btmgrPersist.json"
+#define BTRMGR_PERSISTENT_DATA_PATH_SECURE "/opt/secure/lib/bluetooth/btmgrPersist.json"
+#define BTRMGR_PERSISTENT_DATA_PATH BTRMGR_PERSISTENT_DATA_PATH_SECURE
 #endif
 #define BTRMGR_A2DP_SRC_PROFILE_ID  "0x110a"
 #define BTRMGR_A2DP_SINK_PROFILE_ID "0x110b"

--- a/src/persistIf/btrMgr_persistIface.c
+++ b/src/persistIf/btrMgr_persistIface.c
@@ -69,8 +69,8 @@ typedef struct _stBTRMgrPIHdl {
 } stBTRMgrPIHdl;
 
 /* Static Function Prototypes */
-static char* readPersistentFile (char*  fileContent);
-static void writeToPersistentFile (char* fileName,cJSON* profileData);
+static char* readPersistentFile (const char*  fileContent);
+static void writeToPersistentFile (const char* fileName,cJSON* profileData);
 static eBTRMgrRet BTRMgr_PI_SetLastConnectedDevice(unsigned long long int deviceID);
 
 /* Local Op Threads Prototypes*/
@@ -80,7 +80,7 @@ static eBTRMgrRet BTRMgr_PI_SetLastConnectedDevice(unsigned long long int device
 /* Static Function Definition */
 static char*
 readPersistentFile (
-    char*   fileName
+    const char*   fileName
 ) {
     FILE *fp = NULL;
     char *fileContent = NULL;
@@ -120,7 +120,7 @@ readPersistentFile (
 
 static void
 writeToPersistentFile (
-    char*   fileName,
+    const char*   fileName,
     cJSON*  profileData
 ) {
     FILE *fp = NULL;

--- a/src/persistIf/btrMgr_persistIface.c
+++ b/src/persistIf/btrMgr_persistIface.c
@@ -48,6 +48,22 @@
 #define BTRMGR_PI_DEVID_LEN     17
 #define BTRMGR_PI_VOL_LEN       4
 
+#ifndef UNIT_TEST
+static const char*
+btrMgr_PI_GetPersistentDataPath(
+    void
+) {
+    if (access("/opt/lib/bluetooth/", F_OK) == 0) {
+        return BTRMGR_PERSISTENT_DATA_PATH_OPT_LIB;
+    }
+
+    return BTRMGR_PERSISTENT_DATA_PATH_SECURE;
+}
+
+#undef BTRMGR_PERSISTENT_DATA_PATH
+#define BTRMGR_PERSISTENT_DATA_PATH btrMgr_PI_GetPersistentDataPath()
+#endif
+
 typedef struct _stBTRMgrPIHdl {
     BTRMGR_PersistentData_t piData;
 } stBTRMgrPIHdl;


### PR DESCRIPTION
Reason for change: Migrate bluetooth pairing data to /opt/secure
Test Procedure: Do bluetooth regression test

Risks: Medium
Priority: P1