### PR TITLE
RDKOSS-1008: Wait for A2DP disconnect confirmation in BTRMGR_DeInit

### DIFF
--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -4134,7 +4134,9 @@ BTRMGR_DeInit (
 
                     if (!ui32PollCount) {
                         BTRMGRLOG_WARN("Disconnect confirmation timeout for device %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
-                    }
+                    } else {
+                        BTRMGRLOG_WARN("Disconnect confirmed for device %llu in %dms\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle, (10 - ui32PollCount) * 100);
+		            }
 				}
             }
         }

--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -4125,7 +4125,7 @@ BTRMGR_DeInit (
                     BTRMGRLOG_ERROR ("Failed to Disconnect - %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
                 }
                 if (lenBtrCoreDevTy == enBTRCoreSpeakers || lenBtrCoreDevTy == enBTRCoreHeadSet) {
-                    unsigned int ui32PollCount = 10;  /* 10 × 100ms = 1000ms max */
+                    unsigned int ui32PollCount = 7;  /* 7 × 100ms = 700ms max */
 
                     do {
                         usleep(100000);  /* 100ms */

--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -4125,7 +4125,7 @@ BTRMGR_DeInit (
                     BTRMGRLOG_ERROR ("Failed to Disconnect - %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
                 }
                 if (lenBtrCoreDevTy == enBTRCoreSpeakers || lenBtrCoreDevTy == enBTRCoreHeadSet) {
-                    unsigned int ui32PollCount = 10;  /* 10 × 100ms = 1s max */
+                    unsigned int ui32PollCount = 5;  /* 5 × 100ms = 500ms max */
 
                     do {
                         usleep(100000);  /* 100ms */

--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -4127,15 +4127,16 @@ BTRMGR_DeInit (
                 if (lenBtrCoreDevTy == enBTRCoreSpeakers || lenBtrCoreDevTy == enBTRCoreHeadSet) {
                     unsigned int ui32PollCount = 10;  /* 10 × 100ms = 1s max */
 
-                do {
-                    usleep(100000);  /* 100ms */
-                    lenBtrCoreRet = BTRCore_GetDeviceDisconnected(ghBTRCoreHdl,lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle,lenBtrCoreDevTy);
-                } while ((lenBtrCoreRet != enBTRCoreSuccess) && (--ui32PollCount));
+                    do {
+                        usleep(100000);  /* 100ms */
+                        lenBtrCoreRet = BTRCore_GetDeviceDisconnected(ghBTRCoreHdl,lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle,lenBtrCoreDevTy);
+                    } while ((lenBtrCoreRet != enBTRCoreSuccess) && (--ui32PollCount));
 
-                if (!ui32PollCount) {
-                    BTRMGRLOG_WARN("Disconnect confirmation timeout for device %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
-                }
-            }	
+                    if (!ui32PollCount) {
+                        BTRMGRLOG_WARN("Disconnect confirmation timeout for device %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
+                    }
+				}
+            }
         }
     }
 

--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -4125,7 +4125,7 @@ BTRMGR_DeInit (
                     BTRMGRLOG_ERROR ("Failed to Disconnect - %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
                 }
                 if (lenBtrCoreDevTy == enBTRCoreSpeakers || lenBtrCoreDevTy == enBTRCoreHeadSet) {
-                    unsigned int ui32PollCount = 7;  /* 7 × 100ms = 700ms max */
+                    unsigned int ui32PollCount = 10;  /* 10 × 100ms = 1000ms max */
 
                     do {
                         usleep(100000);  /* 100ms */

--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -4125,7 +4125,7 @@ BTRMGR_DeInit (
                     BTRMGRLOG_ERROR ("Failed to Disconnect - %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
                 }
                 if (lenBtrCoreDevTy == enBTRCoreSpeakers || lenBtrCoreDevTy == enBTRCoreHeadSet) {
-                    unsigned int ui32PollCount = 5;  /* 5 × 100ms = 500ms max */
+                    unsigned int ui32PollCount = 10;  /* 10 × 100ms = 1000ms max */
 
                     do {
                         usleep(100000);  /* 100ms */

--- a/src/ifce/btrMgr.c
+++ b/src/ifce/btrMgr.c
@@ -4124,7 +4124,18 @@ BTRMGR_DeInit (
                 if (BTRCore_DisconnectDevice(ghBTRCoreHdl, lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle, lenBtrCoreDevTy) != enBTRCoreSuccess) {
                     BTRMGRLOG_ERROR ("Failed to Disconnect - %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
                 }
-            }
+                if (lenBtrCoreDevTy == enBTRCoreSpeakers || lenBtrCoreDevTy == enBTRCoreHeadSet) {
+                    unsigned int ui32PollCount = 10;  /* 10 × 100ms = 1s max */
+
+                do {
+                    usleep(100000);  /* 100ms */
+                    lenBtrCoreRet = BTRCore_GetDeviceDisconnected(ghBTRCoreHdl,lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle,lenBtrCoreDevTy);
+                } while ((lenBtrCoreRet != enBTRCoreSuccess) && (--ui32PollCount));
+
+                if (!ui32PollCount) {
+                    BTRMGRLOG_WARN("Disconnect confirmation timeout for device %llu\n", lstConnectedDevices.m_deviceProperty[ui16LoopIdx].m_deviceHandle);
+                }
+            }	
         }
     }
 


### PR DESCRIPTION
Reason for change : Added wait time (max 500ms) for audio device disconnect confirmation before exiting D-Bus. Without this, btmgr exits while AVDTP CLOSE signaling is still in-flight, causing bluetoothd to crash in clear_endpoint when the response arrives after endpoint destruction.